### PR TITLE
[PLA-2449] Remove api url and user agent

### DIFF
--- a/PlatformSampleGameServer.csproj
+++ b/PlatformSampleGameServer.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>PlatformSampleGameServer</RootNamespace>
     <AssemblyName>PlatformSampleGameServer</AssemblyName>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PlatformSampleGameServer.csproj
+++ b/PlatformSampleGameServer.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>PlatformSampleGameServer</RootNamespace>
     <AssemblyName>PlatformSampleGameServer</AssemblyName>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Unity client sends them as strings too.
    | Setting | Default | Meaning |
    |---|---|---|
    | `Server.Port` | `3000` | HTTP listen port. The Unity client expects 3000 by default. |
-   | `Enjin.ApiUrl` | Canary GraphQL | Switch to production when you ship. |
    | `Enjin.Network` / `Enjin.Chain` | `Canary` / `Matrix` | |
    | `Enjin.ResourceTokens` | three entries | The Unity client has matching `EnjinItem` assets for `Id` 1, 2, 3. |
    | `Enjin.CollectionName` | `Enjin Sample Game` | Used to find or reuse an existing collection so you don't create a new one every run. |

--- a/Services/EnjinService.cs
+++ b/Services/EnjinService.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Reflection;
 using System.Text.Json;
 using Enjin.Platform.Sdk;
 using Microsoft.Extensions.Options;
@@ -28,6 +29,36 @@ namespace PlatformSampleGameServer.Services;
 //    by the player's email as externalId.
 public sealed class EnjinService : IAsyncDisposable
 {
+    // User-Agent sent to the platform, e.g. "platform-sample-game-server/1.0.0".
+    // Version comes from the assembly (set via <Version> in the .csproj). Mirrors
+    // the Enjin SDK's PlatformClient.BuildDefaultUserAgent so prerelease tags carry
+    // through (InformationalVersion preferred over the numeric AssemblyVersion).
+    private static readonly string UserAgent = "platform-sample-game-server/" + GetVersion();
+
+    private static string GetVersion()
+    {
+        var asm = typeof(EnjinService).Assembly;
+        var version =
+            asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? asm.GetName().Version?.ToString(3)
+            ?? "unknown";
+
+        // Strip SourceLink commit suffix like "1.0.0+abc1234".
+        var plus = version.IndexOf('+');
+        if (plus >= 0)
+        {
+            version = version[..plus];
+        }
+
+        // Strip a leading "v" so the header carries a plain SemVer value.
+        if (version.StartsWith('v'))
+        {
+            version = version[1..];
+        }
+
+        return version;
+    }
+
     private readonly PlatformClient _client;
     private readonly EnjinOptions _opts;
     private readonly ServerState _state;
@@ -49,8 +80,6 @@ public sealed class EnjinService : IAsyncDisposable
         _network = _opts.Network;
         _chain = _opts.Chain;
 
-        if (string.IsNullOrWhiteSpace(_opts.ApiUrl))
-            throw new InvalidOperationException("Enjin:ApiUrl is not configured.");
         if (string.IsNullOrWhiteSpace(_opts.ApiToken))
             throw new InvalidOperationException("Enjin:ApiToken is not configured.");
         if (string.IsNullOrWhiteSpace(_opts.DaemonWalletAddress))
@@ -66,10 +95,7 @@ public sealed class EnjinService : IAsyncDisposable
                 "Enjin:ResourceTokens is empty. Configure at least one resource token definition (id, name, media)."
             );
 
-        _client = new PlatformClient(
-            new Uri(_opts.ApiUrl),
-            userAgent: "platform-sample-game-server/1.0"
-        );
+        _client = new PlatformClient(userAgent: UserAgent);
         _client.Auth(_opts.ApiToken);
     }
 

--- a/Services/EnjinService.cs
+++ b/Services/EnjinService.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using System.Reflection;
 using System.Text.Json;
 using Enjin.Platform.Sdk;
 using Microsoft.Extensions.Options;
@@ -29,36 +28,6 @@ namespace PlatformSampleGameServer.Services;
 //    by the player's email as externalId.
 public sealed class EnjinService : IAsyncDisposable
 {
-    // User-Agent sent to the platform, e.g. "platform-sample-game-server/1.0.0".
-    // Version comes from the assembly (set via <Version> in the .csproj). Mirrors
-    // the Enjin SDK's PlatformClient.BuildDefaultUserAgent so prerelease tags carry
-    // through (InformationalVersion preferred over the numeric AssemblyVersion).
-    private static readonly string UserAgent = "platform-sample-game-server/" + GetVersion();
-
-    private static string GetVersion()
-    {
-        var asm = typeof(EnjinService).Assembly;
-        var version =
-            asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-            ?? asm.GetName().Version?.ToString(3)
-            ?? "unknown";
-
-        // Strip SourceLink commit suffix like "1.0.0+abc1234".
-        var plus = version.IndexOf('+');
-        if (plus >= 0)
-        {
-            version = version[..plus];
-        }
-
-        // Strip a leading "v" so the header carries a plain SemVer value.
-        if (version.StartsWith('v'))
-        {
-            version = version[1..];
-        }
-
-        return version;
-    }
-
     private readonly PlatformClient _client;
     private readonly EnjinOptions _opts;
     private readonly ServerState _state;
@@ -95,7 +64,7 @@ public sealed class EnjinService : IAsyncDisposable
                 "Enjin:ResourceTokens is empty. Configure at least one resource token definition (id, name, media)."
             );
 
-        _client = new PlatformClient(userAgent: UserAgent);
+        _client = new PlatformClient();
         _client.Auth(_opts.ApiToken);
     }
 

--- a/Services/Options.cs
+++ b/Services/Options.cs
@@ -6,7 +6,6 @@ namespace PlatformSampleGameServer.Services;
 // (and overrides) via IOptions<EnjinOptions>.
 public sealed class EnjinOptions
 {
-    public string ApiUrl { get; set; } = "";
     public string ApiToken { get; set; } = "";
 
     // Default to the Canary test network on Matrix relay. Override per environment.

--- a/appsettings.Sample.json
+++ b/appsettings.Sample.json
@@ -4,7 +4,6 @@
     "Secret": "replace-with-a-long-random-string-at-least-32-chars"
   },
   "Enjin": {
-    "ApiUrl": "https://platform.canary.enjin.io/graphql",
     "ApiToken": "your-enjin-platform-bearer-token-here",
     "DaemonWalletAddress": "your-daemon-wallet-ss58-address"
   }

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,7 +17,6 @@
     "ExpiryHours": 24
   },
   "Enjin": {
-    "ApiUrl": "https://platform.canary.enjin.io/graphql",
     "ApiToken": "",
     "Network": "Canary",
     "Chain": "Matrix",


### PR DESCRIPTION
- remove `ApiUrl` - this will cause it to always use default value of the SDK, which is `https://platform.enjin.io/graphql`
- also don't pass a user agent to the sdk client