### PR TITLE
[PLA-2471] Update sample game server for Enjin Platform SDK 3.0.3

### DIFF
--- a/PlatformSampleGameServer.csproj
+++ b/PlatformSampleGameServer.csproj
@@ -22,6 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Enjin.Platform.Sdk" Version="3.0.2" />
+    <PackageReference Include="Enjin.Platform.Sdk" Version="3.0.3" />
   </ItemGroup>
 </Project>

--- a/Services/EnjinService.cs
+++ b/Services/EnjinService.cs
@@ -254,8 +254,6 @@ public sealed class EnjinService : IAsyncDisposable
     {
         var query = new QueryQueryBuilder().WithGetManagedWallet(
             new ManagedWalletQueryBuilder().WithPublicKey().WithExternalId(),
-            _network,
-            _chain,
             externalId: externalId
         );
 
@@ -357,7 +355,11 @@ public sealed class EnjinService : IAsyncDisposable
 
         var input = new TransactionInput
         {
-            TransferEnj = new TransferEnjInput { Recipient = recipientAddress, Amount = amount },
+            TransferEnj = new TransferEnjInput
+            {
+                Recipient = recipientAddress,
+                Amount = amount.ToString(),
+            },
         };
 
         try
@@ -400,8 +402,6 @@ public sealed class EnjinService : IAsyncDisposable
         // Step 1: locate the managed wallet's public key.
         var mwQuery = new QueryQueryBuilder().WithGetManagedWallet(
             new ManagedWalletQueryBuilder().WithPublicKey().WithExternalId(),
-            _network,
-            _chain,
             externalId: externalId
         );
 
@@ -625,7 +625,7 @@ public sealed class EnjinService : IAsyncDisposable
             ct.ThrowIfCancellationRequested();
 
             var query = new QueryQueryBuilder().WithGetTransaction(
-                new TransactionQueryBuilder().WithUuid().WithState().WithExtrinsicHash(),
+                new TransactionQueryBuilder().WithUuid().WithState(),
                 _network,
                 _chain,
                 uuid: uuid


### PR DESCRIPTION
Bump the Enjin.Platform.Sdk PackageReference from 3.0.2 to 3.0.3 and adapt EnjinService to the SDK's breaking changes so the server compiles and round-trips against the v3 schema.

- GetManagedWallet no longer accepts network/chain arguments, dropped from both call sites;
- TransferEnjInput.Amount changed from BigInteger to string (ENJ scalar), so the drip amount is sent via amount.ToString();
- Transaction.extrinsicHash was removed (the hash now lives on the nested Extrinsic object), so it is no longer selected in the GetTransaction poll where it was unused.